### PR TITLE
Fix timezone handling in solar elevation calculations

### DIFF
--- a/Sources/Astral/Sun.swift
+++ b/Sources/Astral/Sun.swift
@@ -303,13 +303,10 @@ func zenith_and_azimuth(
   let longitude = observer.longitude
 
   // Determine the UTC time from the provided time zone.
-  let zone: Double
   let utcDatetime: DateComponents
   if let tz = dateandtime.timeZone {
-    zone = -Double(tz.secondsFromGMT()) / 3600.0
     utcDatetime = dateandtime.astimezone(.utc)
   } else {
-    zone = 0.0
     utcDatetime = dateandtime
   }
 
@@ -318,8 +315,8 @@ func zenith_and_azimuth(
   let declination = sun_declination(juliancentury: t)
   let eqtime = eq_of_time(juliancentury: t)
 
-  // True solar time adjustment.
-  let solarTimeFix = eqtime + (4.0 * longitude) + (60.0 * zone)
+  // True solar time adjustment (no timezone offset since we're already in UTC).
+  let solarTimeFix = eqtime + (4.0 * longitude)
   let totalMinutes = Double((utcDatetime.hour ?? 0) * 60 + (utcDatetime.minute ?? 0))
     + (Double(utcDatetime.second ?? 0) / 60.0)
   var trueSolarTime = totalMinutes + solarTimeFix


### PR DESCRIPTION
## Summary
- Fix double timezone conversion bug in `zenith_and_azimuth()` function
- Resolve final failing test `testElevation_Nonnative` 
- Achieve 100% test suite success rate (125/125 tests passing)

## Problem
The `testElevation_Nonnative` test was failing because timezone-aware DateComponents were being double-converted:
1. First converted from `GMT+5:30` to UTC correctly
2. Then timezone offset applied again in solar time calculation (incorrect)

This caused elevation calculations to return 78.04° instead of the expected 7.41°.

## Solution
- Removed redundant `zone` variable and timezone offset calculation
- Updated solar time calculation to work with already-converted UTC time
- The fix ensures timezone conversion happens only once, as intended

## Testing
- ✅ All 125 tests now pass (100% success rate)
- ✅ `testElevation_Nonnative` specifically fixed
- ✅ No regressions in existing functionality
- ✅ Timezone-aware astronomical calculations work correctly

## Files Changed
- `Sources/Astral/Sun.swift` - Fixed `zenith_and_azimuth()` function

🤖 Generated with [Claude Code](https://claude.ai/code)